### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,15 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.16.x, 1.17.x]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Test
       run: go test -race -v .


### PR DESCRIPTION
## Updates

- Go test versions: 1.16.x, 1.17.x
- GitHub Actions: updated to pinned hashes

---
Created by mygithelper