### PR TITLE
ci: Fix cache warnings by moving checkout step first

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Install Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Test
       run: go test -race -v .


### PR DESCRIPTION
## Summary
- Move checkout step to be the first step in the workflow to fix "Restore cache failed" warnings
- The warning occurs because setup-go tries to cache Go modules before the source is checked out

## Test plan
- [ ] Verify the CI workflow runs without cache warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)